### PR TITLE
Add offline support

### DIFF
--- a/demo/offline.html
+++ b/demo/offline.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Service Worker Plugin</title>
+  <link rel="stylesheet" text="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/styles/monokai-sublime.min.css" />
+  <link rel="manifest" href="manifest.json">
+  <style>html { background: #23241f }</style>
+</head>
+<body>
+  <pre><code id="sw" class="js"></code></pre>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.9.0/highlight.min.js"></script>
+  <script src="runtime.js"></script>
+</body>
+</html>

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -34,6 +34,7 @@ module.exports = {
     new ServiceWorkerPlugin(DEFAULT_SW_CONFIG, {
       withCache: Object.assign({}, DEFAULT_SW_CONFIG, {
         cache: {
+          offlineURL: '/offline.html',
           precache: [
             '.*\\.js$'
           ],

--- a/packages/generate-service-worker/utils/validators.js
+++ b/packages/generate-service-worker/utils/validators.js
@@ -6,6 +6,7 @@ const StrategyShape = V.shape({
 });
 
 const CacheShape = V.shape({
+  offlineURL: V.string,
   precache: V.arrayOfType(V.string),
   strategy: V.arrayOfType(StrategyShape)
 });

--- a/testing/fixtures.js
+++ b/testing/fixtures.js
@@ -1,6 +1,7 @@
 const Request = (extras) => Object.assign({
   method: 'GET',
-  url: 'test.js'
+  url: 'test.js',
+  headers: { get: name => name }
 }, extras);
 
 const Response = (extras) => Object.assign({


### PR DESCRIPTION
This allows you to specify a `cache.offlineURL`. The response from this URL will be precached and used for any offline navigation requests.