### PR TITLE
Update docs for offline support

### DIFF
--- a/packages/generate-service-worker/README.md
+++ b/packages/generate-service-worker/README.md
@@ -16,6 +16,7 @@ const generateServiceWorkers = require('generate-service-worker');
 
 const serviceWorkers = generateServiceWorkers({
   cache: {
+    offline: true,
     precache: ['/static/js/bundle-81hj9isadf973adfsh10.js'],
     strategy: [{
       type: 'prefer-cache',
@@ -38,9 +39,10 @@ const serviceWorkers = generateServiceWorkers({
 GenerateServiceWorker currently supports caching and notifications. The following are the configuration options for each.
 
 ### Caching
-The `cache` key is used for defining caching strategies. The strings in `precache` will be used to prefetch assets and insert them into the cache. The regexes in `strategy.matches` are used at runtime to determine which strategy to use for a given GET request. All cached items will be removed at installation of a new service worker version. Additionally, you can use your own custom cache template by including the full path in the `template` property. We suggest forking our `templates/cache.js` file to get started and to be familiar with how variable injection works in the codebase.
+The `cache` key is used for defining caching strategies. The strings in `precache` will be used to prefetch assets and insert them into the cache. The regexes in `strategy.matches` are used at runtime to determine which strategy to use for a given GET request. All cached items will be removed at installation of a new service worker version. Additionally, you can use your own custom cache template by including the full path in the `template` property. We suggest forking our `templates/cache.js` file to get started and to be familiar with how variable injection works in the codebase. If the `offline` option is set to `true`, the service worker will assume that an html response is an "App Shell". It will cache the html response and return it only in the case of a static route change while offline.
 ```js
 const CacheType = {
+  offline?: boolean,
   precache?: Array<string>,
   strategy?: Array<StrategyType>,
   template?: string,

--- a/packages/generate-service-worker/utils/validate.js
+++ b/packages/generate-service-worker/utils/validate.js
@@ -52,6 +52,12 @@ function shapeValidation(objShape) {
   });
 }
 
+function booleanValidation(value) {
+  if (!value || typeof value !== 'boolean') {
+    throw `Value ${value} must be of type "boolean".`;
+  }
+}
+
 function objectValidation(value) {
   if (!value || typeof value !== 'object') {
     throw `Value ${value} must be non-null "object".`;
@@ -85,6 +91,7 @@ function withRequired(_validator) {
 }
 
 module.exports = {
+  boolean: withRequired(booleanValidation),
   object: withRequired(objectValidation),
   number: withRequired(numberValidation),
   string: withRequired(stringValidation),

--- a/packages/generate-service-worker/utils/validators.js
+++ b/packages/generate-service-worker/utils/validators.js
@@ -6,7 +6,7 @@ const StrategyShape = V.shape({
 });
 
 const CacheShape = V.shape({
-  offlineURL: V.string,
+  offline: V.boolean,
   precache: V.arrayOfType(V.string),
   strategy: V.arrayOfType(StrategyShape)
 });

--- a/packages/service-worker-plugin/README.md
+++ b/packages/service-worker-plugin/README.md
@@ -14,6 +14,7 @@ const ServiceWorkerPlugin = require('service-worker-plugin');
 
 const rootConfig = {
   cache: {
+    offline: true,
     precache: ['\\.js'],
     strategy: [{
       type: 'prefer-cache',
@@ -57,9 +58,10 @@ if (inPrecacheExperiment) {
 ServiceWorkerPlugin currently supports caching and notifications. The following are the configuration options for each.
 
 ### Caching
-The `cache` key is used for defining caching strategies. The regexes in `precache` will be used to resolve webpack-generated assets to hard-coded paths for precaching. The regexes in `strategy.matches` are used at runtime to determine which strategy to use for a given GET request. All cached items will be removed at installation of a new service worker version. Additionally, you can use your own custom cache template by including the full path in the `template` property. We suggest forking our `templates/cache.js` file to get started and to be familiar with how variable injection works in the codebase.
+The `cache` key is used for defining caching strategies. The regexes in `precache` will be used to resolve webpack-generated assets to hard-coded paths for precaching. The regexes in `strategy.matches` are used at runtime to determine which strategy to use for a given GET request. All cached items will be removed at installation of a new service worker version. Additionally, you can use your own custom cache template by including the full path in the `template` property. We suggest forking our `templates/cache.js` file to get started and to be familiar with how variable injection works in the codebase. If the `offline` option is set to `true`, the service worker will assume that an html response is an "App Shell". It will cache the html response and return it only in the case of a static route change while offline.
 ```js
 const CacheType = {
+  offline?: boolean,
   precache?: Array<regex>,
   strategy?: Array<StrategyType>,
   template?: string,


### PR DESCRIPTION
Support while offline is supported, but the docs were missing any explanation. Essentially, if you want to enable "offline" support, you should be using an App Shell for your html response, and set the `offline` option to true in caching. It's as simple as:
```js
const config = {
    cache: {
        offline: true
    }
};
```
With `offline` set to true, the service worker will cache the HTML response for the page and use it in the case of an offline static route change.