### PR TITLE
Use cors mode with origin response.

### DIFF
--- a/packages/generate-service-worker/templates/cache.js
+++ b/packages/generate-service-worker/templates/cache.js
@@ -56,11 +56,7 @@ function handleFetch(event) {
       event.respondWith(
         applyEventStrategy(strategy, event).then(response => {
           logger.groupEnd(event.request.url);
-          return {
-            response,
-            // Origin is required for the client to receive a cors response.
-            origin: event.origin
-          };
+          return response;
         }).catch(() => undefined)
       );
     }

--- a/packages/generate-service-worker/templates/cache.js
+++ b/packages/generate-service-worker/templates/cache.js
@@ -59,7 +59,7 @@ function handleFetch(event) {
           return {
             response,
             // Origin is required for the client to receive a cors response.
-            origin: event.origin,
+            origin: event.origin
           };
         }).catch(() => undefined)
       );

--- a/packages/generate-service-worker/templates/cache.js
+++ b/packages/generate-service-worker/templates/cache.js
@@ -56,7 +56,11 @@ function handleFetch(event) {
       event.respondWith(
         applyEventStrategy(strategy, event).then(response => {
           logger.groupEnd(event.request.url);
-          return response;
+          return {
+            response,
+            // Origin is required for the client to receive a cors response.
+            origin: event.origin,
+          };
         }).catch(() => undefined)
       );
     }
@@ -184,7 +188,7 @@ function precache() {
         const cacheBustedUrl = new URL(urlToPrefetch, location.href);
         cacheBustedUrl.search += (cacheBustedUrl.search ? '&' : '?') + `cache-bust=${Date.now()}`;
 
-        const request = new Request(cacheBustedUrl, { mode: 'no-cors' });
+        const request = new Request(cacheBustedUrl, { mode: 'cors' });
         return fetch(request).then(response => {
           if (!isValidResponse(response)) {
             logger.error(`Failed for ${urlToPrefetch}.`, 'precaching');


### PR DESCRIPTION
We need to set the origin header as well so the client sees cors requests. Without it the client will receive an opaque response.