### PR TITLE
service-worker-mock: adds stubs for Request & Response, and a real URL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 npm-debug.log
 demo/sw-*.js
 packages/service-worker-plugin/runtime.js
+.idea

--- a/packages/service-worker-mock/README.md
+++ b/packages/service-worker-mock/README.md
@@ -3,7 +3,7 @@ Service Worker Mock
 A mock service worker environment generator.
 
 ## Why?
-Testing service workers is difficult. Each file produces side-effects by calls to `self.addEventListener`, and the service worker environment is unlike a normal web or node context. This package makes it easy to turn any environment into a feaux service worker environment. Additionally, it adds some helpful methods for testing integrations.
+Testing service workers is difficult. Each file produces side-effects by calls to `self.addEventListener`, and the service worker environment is unlike a normal web or node context. This package makes it easy to turn a Node.js environment into a faux service worker environment. Additionally, it adds some helpful methods for testing integrations.
 
 The service worker mock creates an environment with the following properties, based on the current [Mozilla Service Worker Docs](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API).
 ```js
@@ -14,6 +14,9 @@ const env = {
   clients: Clients,
   registration: ServiceWorkerRegistration,
   addEventListener: Function,
+  Request: constructor Function,
+  Response: constructor Function,
+  URL: constructor Function,
 
   // Test helpers
   listeners: Object,

--- a/packages/service-worker-mock/index.js
+++ b/packages/service-worker-mock/index.js
@@ -1,7 +1,10 @@
+const url = require('url');
 const CacheStorage = require('./models/CacheStorage');
 const Clients = require('./models/Clients');
 const ServiceWorkerRegistration = require('./models/ServiceWorkerRegistration');
 const handleEvents = require('./utils/events').handleEvents;
+const Request = require('./models/Request');
+const Response = require('./models/Response');
 
 module.exports = function makeServiceWorkerEnv() {
   const env = {
@@ -29,8 +32,11 @@ module.exports = function makeServiceWorkerEnv() {
         clients: env.clients.snapshot(),
         notifications: env.registration.snapshot()
       };
-    }
-  };
+    },
+    Request: Request,
+    Response: Response,
+    URL: url.URL || url.parse,
+};
 
   env.self = env;
 

--- a/packages/service-worker-mock/index.js
+++ b/packages/service-worker-mock/index.js
@@ -35,8 +35,8 @@ module.exports = function makeServiceWorkerEnv() {
     },
     Request: Request,
     Response: Response,
-    URL: url.URL || url.parse,
-};
+    URL: url.URL || url.parse
+  };
 
   env.self = env;
 

--- a/packages/service-worker-mock/models/Headers.js
+++ b/packages/service-worker-mock/models/Headers.js
@@ -1,0 +1,9 @@
+// stubs https://developer.mozilla.org/en-US/docs/Web/API/Headers
+
+class Headers {
+  get() {
+    return '';
+  }
+}
+
+module.exports = Headers;

--- a/packages/service-worker-mock/models/Request.js
+++ b/packages/service-worker-mock/models/Request.js
@@ -1,0 +1,17 @@
+// stubs https://developer.mozilla.org/en-US/docs/Web/API/Request
+class Request {
+  constructor(url, options) {
+    this.url = url || 'http://example.com/something';
+    this.method = (options && options.method) || 'GET';
+    this.mode = (options && options.mode) || 'navigate';
+  }
+
+  clone() {
+    return new Request(this.url, {
+      method: this.method,
+      mode: this.mode
+    });
+  }
+}
+
+module.exports = Request;

--- a/packages/service-worker-mock/models/Request.js
+++ b/packages/service-worker-mock/models/Request.js
@@ -1,9 +1,12 @@
 // stubs https://developer.mozilla.org/en-US/docs/Web/API/Request
+const Headers = require('./Headers');
+
 class Request {
   constructor(url, options) {
-    this.url = url || 'http://example.com/something';
+    this.url = url || 'http://example.com/some.js';
     this.method = (options && options.method) || 'GET';
-    this.mode = (options && options.mode) || 'navigate';
+    this.mode = (options && options.mode) || 'same-origin';   // FF defaults to cors
+    this.headers = (options && options.headers) || new Headers();
   }
 
   clone() {

--- a/packages/service-worker-mock/models/Response.js
+++ b/packages/service-worker-mock/models/Response.js
@@ -1,0 +1,21 @@
+// stubs https://developer.mozilla.org/en-US/docs/Web/API/Response
+class Response {
+  constructor(body, init) {
+    this.body = body;
+    this.status = (init && init.status) || 200;
+    this.statusText = (init && init.statusText) || 'OK';
+    this.headers = (init && init.headers);
+
+    this.type = 'basic';
+  }
+
+  clone() {
+    return new Response(this.body, {
+      status: this.status,
+      statusText: this.statusText,
+      headers: this.headers
+    });
+  }
+}
+
+module.exports = Response;

--- a/packages/service-worker-mock/models/Response.js
+++ b/packages/service-worker-mock/models/Response.js
@@ -1,12 +1,15 @@
 // stubs https://developer.mozilla.org/en-US/docs/Web/API/Response
 class Response {
   constructor(body, init) {
-    this.body = body;
+    this.body = body || '';
     this.status = (init && init.status) || 200;
+    this.ok = this.status >= 200 && this.status < 300;
     this.statusText = (init && init.statusText) || 'OK';
     this.headers = (init && init.headers);
 
     this.type = 'basic';
+    this.redirected = false;
+    this.url = 'http://example.com/asset';
   }
 
   clone() {
@@ -15,6 +18,14 @@ class Response {
       statusText: this.statusText,
       headers: this.headers
     });
+  }
+
+  text() {
+    try {
+      return Promise.resolve(this.body.toString());
+    } catch (err) {
+      return Promise.resolve(Object.prototype.toString.apply(this.body));
+    }
   }
 }
 

--- a/packages/service-worker-mock/package.json
+++ b/packages/service-worker-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-worker-mock",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/testing/fixtures.js
+++ b/testing/fixtures.js
@@ -1,15 +1,3 @@
-const Request = (extras) => Object.assign({
-  method: 'GET',
-  url: 'test.js',
-  headers: { get: name => name }
-}, extras);
-
-const Response = (extras) => Object.assign({
-  ok: true,
-  value: 42,
-  clone: () => Response(extras)
-}, extras);
-
 /*    External Fixtures   */
 
 const Cache = (overrides) => Object.assign({
@@ -74,8 +62,6 @@ const $Log = (override) => override || ({
 });
 
 module.exports = {
-  Request,
-  Response,
   // External
   Cache,
   Event,


### PR DESCRIPTION
Fleshes out service-worker-mock with constructors needed by robust Service Workers, such as
```js
    var url = new URL(request.url);
    if (request.mode === 'cors' ||
            ['GET', 'HEAD', 'OPTIONS'].indexOf(request.method) < 0 ||
            (url.protocol !== "http:" && url.protocol !== "https:")) {
        console.log("s.w. not handling:", request.mode, request.method, url.href);
    } else {
        evt.respondWith(cacheOrNetwork(request));
    }
 ```