### PR TITLE
Fix: cache.keys() should return an array of keys

### DIFF
--- a/packages/service-worker-mock/models/Cache.js
+++ b/packages/service-worker-mock/models/Cache.js
@@ -52,7 +52,7 @@ class Cache {
   }
 
   keys() {
-    return Promise.resolve(this.store.keys());
+    return Promise.resolve(Array.from(this.store.keys()));
   }
 
   snapshot() {


### PR DESCRIPTION
Api docs: https://developer.mozilla.org/en-US/docs/Web/API/Cache/keys
Current return type: MapIterator.