### PR TITLE
Fix: Put now overwrites existing key-value pairs

### DIFF
--- a/packages/service-worker-mock/models/Cache.js
+++ b/packages/service-worker-mock/models/Cache.js
@@ -7,7 +7,7 @@ class Cache {
   match(request) {
     const url = request.url || request;
     if (this.store.has(url)) {
-      return Promise.resolve(this.store.get(url)[0]);
+      return Promise.resolve(this.store.get(url));
     }
     return Promise.resolve(null);
   }
@@ -15,7 +15,7 @@ class Cache {
   matchAll(request) {
     const url = request.url || request;
     if (this.store.has(url)) {
-      return Promise.resolve(this.store.get(url));
+      return Promise.resolve([this.store.get(url)]);
     }
     return Promise.resolve(null);
   }
@@ -34,21 +34,13 @@ class Cache {
 
   put(request, response) {
     const url = request.url || request;
-    if (this.store.has(url)) {
-      this.store.get(url).push(response);
-    } else {
-      this.store.set(url, [response]);
-    }
+    this.store.set(url, response);
     return Promise.resolve();
   }
 
   delete(request) {
     const url = request.url || request;
-    if (this.store.has(url)) {
-      this.store.delete(url);
-      return Promise.resolve(true);
-    }
-    return Promise.resolve(false);
+    return Promise.resolve(this.store.delete(url));
   }
 
   keys() {
@@ -63,7 +55,7 @@ class Cache {
       if (typeof entry[0] === 'object') {
         key = JSON.stringify(key);
       }
-      snapshot[key] = entry[1][0];
+      snapshot[key] = entry[1];
     }
     return snapshot;
   }


### PR DESCRIPTION
[MatchAll specifications](https://developer.mozilla.org/en-US/docs/Web/API/Cache/matchAll) states that `it resolves with response[0] (i.e. the first matching response) instead of response (all matching response in an array)`. 

Here `response[0]` refers to `the first fetching record entry of its request to response map, in key insertion order`([reference](https://www.w3.org/TR/service-workers-1/#cache-matchall-method)) instead of "the earliest record that exists in this request-response map that matches this request". In another word, for each request, there will only be one response correspond to it, except when there exists requests with a ["VARY" header](https://developer.mozilla.org/en-US/docs/Web/API/Cache/keys) in its response.

Current implementation is not considering "VARY" headers, so we can just assume that "VARY" header doesn't exist, and each request will only correspond to one and only one response. 

Besides, current implementation introduces a bug when overriding an existing key-value pair. 
When an existing key-value pair is overridden(`put()` then `match()` on an existing request) it will still return the oldest response (`this.store.get(url)[0]`), not the newest one. 
