### PR TITLE
Update Cache.js

### DIFF
--- a/packages/service-worker-mock/models/Cache.js
+++ b/packages/service-worker-mock/models/Cache.js
@@ -44,7 +44,7 @@ class Cache {
   }
 
   keys() {
-    return Promise.resolve(Array.from(this.store.keys()));
+    return Promise.resolve(Array.from(this.store.values()));
   }
 
   snapshot() {


### PR DESCRIPTION
cache.keys() should resolve to an array of Request objects. At the moment this is returning an array of URLs.

Fixes #40 