### PR TITLE
Moving cache object over to using Requests

### DIFF
--- a/packages/service-worker-mock/models/Cache.js
+++ b/packages/service-worker-mock/models/Cache.js
@@ -7,7 +7,8 @@ class Cache {
   match(request) {
     const url = request.url || request;
     if (this.store.has(url)) {
-      return Promise.resolve(this.store.get(url));
+      const value = this.store.get(url);
+      return Promise.resolve(value.response);
     }
     return Promise.resolve(null);
   }
@@ -15,7 +16,8 @@ class Cache {
   matchAll(request) {
     const url = request.url || request;
     if (this.store.has(url)) {
-      return Promise.resolve([this.store.get(url)]);
+      const value = this.store.get(url);
+      return Promise.resolve([value.response]);
     }
     return Promise.resolve(null);
   }
@@ -33,8 +35,11 @@ class Cache {
   }
 
   put(request, response) {
-    const url = request.url || request;
-    this.store.set(url, response);
+    if (typeof request === 'string') {
+      request = new Request(request);
+    }
+
+    this.store.set(request.url, { request, response });
     return Promise.resolve();
   }
 
@@ -44,7 +49,8 @@ class Cache {
   }
 
   keys() {
-    return Promise.resolve(Array.from(this.store.keys()));
+    const values = Array.from(this.store.values());
+    return Promise.resolve(values.map((value) => value.request));
   }
 
   snapshot() {
@@ -55,7 +61,7 @@ class Cache {
       if (typeof entry[0] === 'object') {
         key = JSON.stringify(key);
       }
-      snapshot[key] = entry[1];
+      snapshot[key] = entry[1].response;
     }
     return snapshot;
   }


### PR DESCRIPTION
Fixes #40 

This changes the map store from storing url's and Response objects to storing url to a Response, Request pair.

This is then used to return the Request object as the key for cache entries and Response object for the value. This changes the current behavior of returning String's which isn't to spec.