### PR TITLE
Add ServiceWorkerGlobalScope mock

### DIFF
--- a/packages/service-worker-mock/index.js
+++ b/packages/service-worker-mock/index.js
@@ -6,39 +6,45 @@ const handleEvents = require('./utils/events').handleEvents;
 const Request = require('./models/Request');
 const Response = require('./models/Response');
 
+class ServiceWorkerGlobalScope {
+  constructor() {
+    this.listeners = {};
+    this.location = { origin: '/' };
+    this.skipWaiting = () => Promise.resolve();
+    this.caches = new CacheStorage();
+    this.clients = new Clients();
+    this.registration = new ServiceWorkerRegistration();
+    this.Request = Request;
+    this.Response = Response;
+    this.URL = url.URL || url.parse;
+    this.ServiceWorkerGlobalScope = ServiceWorkerGlobalScope;
+    this.self = this;
+  }
+
+  addEventListener(name, callback) {
+    if (!this.listeners[name]) {
+      this.listeners[name] = [];
+    }
+    this.listeners[name].push(callback);
+  }
+
+  trigger(name, args) {
+    if (this.listeners[name]) {
+      return handleEvents(name, args, this.listeners[name]);
+    }
+    return Promise.resolve();
+  }
+
+  snapshot() {
+    return {
+      caches: this.caches.snapshot(),
+      clients: this.clients.snapshot(),
+      notifications: this.registration.snapshot()
+    };
+  }
+
+}
+
 module.exports = function makeServiceWorkerEnv() {
-  const env = {
-    listeners: {},
-    location: { origin: '/' },
-    skipWaiting: () => Promise.resolve(),
-    caches: new CacheStorage(),
-    clients: new Clients(),
-    registration: new ServiceWorkerRegistration(),
-    addEventListener: function (name, callback) {
-      if (!env.listeners[name]) {
-        env.listeners[name] = [];
-      }
-      env.listeners[name].push(callback);
-    },
-    trigger: function (name, args) {
-      if (env.listeners[name]) {
-        return handleEvents(name, args, env.listeners[name]);
-      }
-      return Promise.resolve();
-    },
-    snapshot: function () {
-      return {
-        caches: env.caches.snapshot(),
-        clients: env.clients.snapshot(),
-        notifications: env.registration.snapshot()
-      };
-    },
-    Request: Request,
-    Response: Response,
-    URL: url.URL || url.parse
-  };
-
-  env.self = env;
-
-  return env;
+  return new ServiceWorkerGlobalScope();
 };

--- a/packages/service-worker-mock/index.js
+++ b/packages/service-worker-mock/index.js
@@ -18,31 +18,34 @@ class ServiceWorkerGlobalScope {
     this.Response = Response;
     this.URL = url.URL || url.parse;
     this.ServiceWorkerGlobalScope = ServiceWorkerGlobalScope;
+
+    // Instance variable to avoid issues with `this`
+    this.addEventListener = (name, callback) => {
+      if (!this.listeners[name]) {
+        this.listeners[name] = [];
+      }
+      this.listeners[name].push(callback);
+    };
+
+    // Instance variable to avoid issues with `this`
+    this.trigger = (name, args) => {
+      if (this.listeners[name]) {
+        return handleEvents(name, args, this.listeners[name]);
+      }
+      return Promise.resolve();
+    };
+
+    // Instance variable to avoid issues with `this`
+    this.snapshot = () => {
+      return {
+        caches: this.caches.snapshot(),
+        clients: this.clients.snapshot(),
+        notifications: this.registration.snapshot()
+      };
+    };
+
     this.self = this;
   }
-
-  addEventListener(name, callback) {
-    if (!this.listeners[name]) {
-      this.listeners[name] = [];
-    }
-    this.listeners[name].push(callback);
-  }
-
-  trigger(name, args) {
-    if (this.listeners[name]) {
-      return handleEvents(name, args, this.listeners[name]);
-    }
-    return Promise.resolve();
-  }
-
-  snapshot() {
-    return {
-      caches: this.caches.snapshot(),
-      clients: this.clients.snapshot(),
-      notifications: this.registration.snapshot()
-    };
-  }
-
 }
 
 module.exports = function makeServiceWorkerEnv() {


### PR DESCRIPTION
This is a change to address #43. The change is to both add a `ServiceWorkerGlobalScope` class to the global scope, and to make sure that `self` is an instance of that class. This required no breaking changes because (fortunately) all class instance variables are iterable and are copied over with `Object.assign`. 

This does 2 things:

1. Adds `global.ServiceWorkerGlobalScope`.
2. Makes `global.self` the current instanceof `global.ServiceWorkerGlobalScope`.