### PR TITLE
fix: Support new scope option

### DIFF
--- a/packages/service-worker-plugin/index.js
+++ b/packages/service-worker-plugin/index.js
@@ -19,7 +19,7 @@ ProgressiveWebappPlugin.prototype.apply = function (compiler) {
 
   // Write the runtime file
   const workerKeys = ['main'].concat(Object.keys(this.experimentConfigs));
-  const generatedRuntime = generateRuntime(workerKeys, publicPath);
+  const generatedRuntime = generateRuntime(workerKeys, this.baseConfig.scope || publicPath);
   fs.writeFileSync(runtimePath, generatedRuntime);
 
   // Generate service workers

--- a/packages/service-worker-plugin/index.js
+++ b/packages/service-worker-plugin/index.js
@@ -19,7 +19,7 @@ ProgressiveWebappPlugin.prototype.apply = function (compiler) {
 
   // Write the runtime file
   const workerKeys = ['main'].concat(Object.keys(this.experimentConfigs));
-  const generatedRuntime = generateRuntime(workerKeys, this.baseConfig.scope || publicPath);
+  const generatedRuntime = generateRuntime(workerKeys, this.baseConfig.runtimePath || publicPath);
   fs.writeFileSync(runtimePath, generatedRuntime);
 
   // Generate service workers


### PR DESCRIPTION
I'm having an issue with this plugin because of the way you register the service worker against the `publicPath` from WebPack...

In our case, we have the following in `output`...

```js
output: {
  path: path.join(__dirname, "public", "assets"),
  filename: "[name].js",
  chunkFilename: "[name]_[chunkhash:20].js",
  publicPath: `/assets/`,
  libraryTarget: "var",
}
```

Since the `generateRuntime` file uses the `publicPath`, https://github.com/pinterest/service-workers/blob/master/packages/service-worker-plugin/utils/generateRuntime.js#L15, the "scope" of the service worker is incorrectly getting set to `http://localhost:3000/assets/` and isn't firing correctly.

I tried to pass `publicPath: "/"` directly into the options for this plugin, but that messed up the `precache` assets because they were getting set as `["/foo.fs"]` instead of `["/assets/foo.js"]`.

The only way I could figure out how to do this was to pass in the following config...

```js
{
  publicPath: "/assets/",
  writePath: path.join(process.cwd(), "public"),
  scope: "/",
  cache: {
    offline: true,
    precache: ["\\.js", "\\.css"],
    strategy: [{
      type: "prefer-cache",
      matches: ["\\.js", "\\.css"],
    }],
  },
}
```

This correctly sets up the service worker at `localhost:3000/sw-main.js` whilst still adding the correct cached paths into the generated service worker.

![](http://d.pr/i/hoJeY+)

![](http://d.pr/i/esPI0+)


According to Google...

> One subtlety with the register() method is the location of the service worker file. You'll notice in this case that the service worker file is at the root of the domain. This means that the service worker's scope will be the entire origin. In other words, this service worker will receive fetch events for everything on this domain. If we register the service worker file at /example/sw.js, then the service worker would only see fetch events for pages whose URL starts with /example/ (i.e. /example/page1/, /example/page2/).

https://developers.google.com/web/fundamentals/primers/service-workers/#register_a_service_worker