### PR TITLE
Update service-worker-mock to use a location URL

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,7 @@
     "$Notifications": true,
     "$Cache": true,
     "$Log": true,
+    "ServiceWorkerGlobalScope": true,
     "expect": true,
     "afterEach": true,
     "beforeEach": true,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "yargs": "^6.6.0"
   },
   "dependencies": {
+    "dom-urls": "^1.1.0",
     "mkdirp": "^0.5.1"
   },
   "jest": {

--- a/packages/generate-service-worker/templates/__tests__/cache.js
+++ b/packages/generate-service-worker/templates/__tests__/cache.js
@@ -6,7 +6,7 @@ global.$VERSION = '18asd9a8dfy923';
 
 // Constants
 const CURRENT_CACHE = `SW_CACHE:${$VERSION}`;
-const TEST_JS_PATH = 'http://example.com/test.js';
+const TEST_JS_PATH = 'https://www.test.com/test.js';
 let cachedResponse;
 let runtimeResponse;
 
@@ -62,7 +62,7 @@ describe('[generate-service-worker/templates] cache', function test() {
         });
       });
 
-      const response = await self.trigger('fetch', new Request(undefined, { mode: 'navigate' }));
+      const response = await self.trigger('fetch', new Request('/', { mode: 'navigate' }));
       expect(response).toEqual(cachedHtml);
     });
 
@@ -74,7 +74,7 @@ describe('[generate-service-worker/templates] cache', function test() {
 
       global.fetch.mockImplementation(() => Promise.resolve(runtimeResponse));
 
-      const response = await self.trigger('fetch', new Request(undefined, { mode: 'navigate' }));
+      const response = await self.trigger('fetch', new Request('/', { mode: 'navigate' }));
       expect(response).toEqual(runtimeResponse);
     });
   });
@@ -94,9 +94,9 @@ describe('[generate-service-worker/templates] cache', function test() {
       global.fetch.mockImplementation(() => Promise.resolve(runtimeResponse));
 
       const cache = await self.caches.open(CURRENT_CACHE);
-      await cache.put(new Request(), cachedResponse);
+      await cache.put(new Request('/test.js'), cachedResponse);
 
-      const response = await self.trigger('fetch', new Request());
+      const response = await self.trigger('fetch', new Request('/test.js'));
       expect(response).toEqual(runtimeResponse);
     });
 
@@ -110,9 +110,9 @@ describe('[generate-service-worker/templates] cache', function test() {
 
       // Fill cache with item
       const cache = await self.caches.open(CURRENT_CACHE);
-      await cache.put(new Request(), cachedResponse);
+      await cache.put(new Request('/test.js'), cachedResponse);
 
-      const response = await self.trigger('fetch', new Request());
+      const response = await self.trigger('fetch', new Request('/test.js'));
       expect(response).toEqual(cachedResponse);
     });
 
@@ -123,7 +123,7 @@ describe('[generate-service-worker/templates] cache', function test() {
           throw new Error('offline');
         });
       });
-      const response = await self.trigger('fetch', new Request());
+      const response = await self.trigger('fetch', new Request('/test.js'));
       expect(response).toEqual(undefined);
     });
   });
@@ -142,7 +142,7 @@ describe('[generate-service-worker/templates] cache', function test() {
     it('should use fetch response if valid', async () => {
       global.fetch.mockImplementation(() => Promise.resolve(runtimeResponse));
 
-      const response = await self.trigger('fetch', new Request());
+      const response = await self.trigger('fetch', new Request('/test.js'));
       expect(response).toEqual(runtimeResponse);
     });
 
@@ -151,16 +151,16 @@ describe('[generate-service-worker/templates] cache', function test() {
 
       // Fill cache with item
       const cache = await self.caches.open(CURRENT_CACHE);
-      await cache.put(new Request(), cachedResponse);
+      await cache.put(new Request('/test.js'), cachedResponse);
 
-      const response = await self.trigger('fetch', new Request());
+      const response = await self.trigger('fetch', new Request('/test.js'));
       expect(response).toEqual(cachedResponse);
     });
 
     it('should fail gracefully if nothing in cache and fetch fails', async () => {
       global.fetch.mockImplementation(() => Promise.resolve(new Response('missing', { status: 404 })));
 
-      const response = await self.trigger('fetch', new Request());
+      const response = await self.trigger('fetch', new Request('/test.js'));
       expect(response).toEqual(undefined);
     });
   });
@@ -181,9 +181,9 @@ describe('[generate-service-worker/templates] cache', function test() {
 
       // Fill cache with item
       const cache = await self.caches.open(CURRENT_CACHE);
-      await cache.put(new Request(), cachedResponse);
+      await cache.put(new Request('/test.js'), cachedResponse);
 
-      const response = await self.trigger('fetch', new Request());
+      const response = await self.trigger('fetch', new Request('/test.js'));
       expect(global.fetch.mock.calls.length).toEqual(0);
       expect(response).toEqual(cachedResponse);
     });
@@ -191,7 +191,7 @@ describe('[generate-service-worker/templates] cache', function test() {
     it('should perform fetch if no cache match', async () => {
       global.fetch.mockImplementation(() => Promise.resolve(runtimeResponse));
 
-      const response = await self.trigger('fetch', new Request());
+      const response = await self.trigger('fetch', new Request('/test.js'));
       expect(global.fetch.mock.calls.length).toEqual(1);
       expect(response).toEqual(runtimeResponse);
     });
@@ -200,7 +200,7 @@ describe('[generate-service-worker/templates] cache', function test() {
       global.fetch.mockImplementation(() => Promise.resolve(runtimeResponse));
 
       expect(self.snapshot().caches[CURRENT_CACHE]).toEqual(undefined);
-      const request = new Request();
+      const request = new Request('/test.js');
       await self.trigger('fetch', request);
       const cacheValue = await self.snapshot().caches[CURRENT_CACHE][request.url].text();
       const runtimeResponseValue = await runtimeResponse.text();
@@ -227,9 +227,9 @@ describe('[generate-service-worker/templates] cache', function test() {
 
       // Fill cache with item
       const cache = await self.caches.open(CURRENT_CACHE);
-      await cache.put(new Request(), cachedResponse);
+      await cache.put(new Request('/test.js'), cachedResponse);
 
-      const response = await self.trigger('fetch', new Request());
+      const response = await self.trigger('fetch', new Request('/test.js'));
       expect(response).toEqual(cachedResponse);
     });
 
@@ -242,9 +242,9 @@ describe('[generate-service-worker/templates] cache', function test() {
 
       // Fill cache with item
       const cache = await self.caches.open(CURRENT_CACHE);
-      await cache.put(new Request(), cachedResponse);
+      await cache.put(new Request('/test.js'), cachedResponse);
 
-      const response = await self.trigger('fetch', new Request());
+      const response = await self.trigger('fetch', new Request('/test.js'));
       expect(response).toEqual(runtimeResponse);
     });
   });

--- a/packages/service-worker-mock/__tests__/basic.js
+++ b/packages/service-worker-mock/__tests__/basic.js
@@ -36,7 +36,7 @@ describe('basic', () => {
     require('./fixtures/basic');
 
     const cachedResponse = { clone: () => {} };
-    const cachedRequest = { url: '/test' };
+    const cachedRequest = new Request('/test');
     const cache = await self.caches.open('TEST');
     cache.put(cachedRequest, cachedResponse);
 
@@ -49,7 +49,7 @@ describe('basic', () => {
     global.fetch = () => Promise.resolve(mockResponse);
     require('./fixtures/basic');
 
-    const request = { url: '/test' };
+    const request = new Request('/test');
     const response = await self.trigger('fetch', request);
     expect(response).toEqual(mockResponse);
     const runtimeCache = self.snapshot().caches.runtime;

--- a/packages/service-worker-mock/__tests__/makeServiceWorkerEnv.js
+++ b/packages/service-worker-mock/__tests__/makeServiceWorkerEnv.js
@@ -1,0 +1,18 @@
+const makeServiceWorkerEnv = require('../index');
+
+describe('installation', () => {
+  it('should make a valid service worker environment', () => {
+    Object.assign(global, makeServiceWorkerEnv());
+    expect(self).toBeDefined();
+    expect(self instanceof ServiceWorkerGlobalScope).toBe(true);
+  });
+
+  it('should allow location overrides', () => {
+    Object.assign(global, makeServiceWorkerEnv({
+      locationUrl: '/scope',
+      locationBase: 'https://oh.yeah'
+    }));
+    expect(self.location instanceof URL).toBe(true);
+    expect(self.location.href).toEqual('https://oh.yeah/scope');
+  });
+});

--- a/packages/service-worker-mock/index.js
+++ b/packages/service-worker-mock/index.js
@@ -1,4 +1,4 @@
-const url = require('url');
+const URL = require('dom-urls');
 
 const Cache = require('./models/Cache');
 const CacheStorage = require('./models/CacheStorage');
@@ -18,10 +18,15 @@ const ServiceWorkerRegistration = require('./models/ServiceWorkerRegistration');
 
 const eventHandler = require('./utils/eventHandler');
 
+const defaults = (envOptions) => Object.assign({
+  locationUrl: 'https://www.test.com'
+}, envOptions);
+
 class ServiceWorkerGlobalScope {
-  constructor() {
+  constructor(envOptions) {
+    const options = defaults(envOptions);
     this.listeners = {};
-    this.location = { origin: '/' };
+    this.location = new URL(options.locationUrl, options.locationBase);
     this.skipWaiting = () => Promise.resolve();
     this.caches = new CacheStorage();
     this.clients = new Clients();
@@ -41,7 +46,7 @@ class ServiceWorkerGlobalScope {
     this.Request = Request;
     this.Response = Response;
     this.ServiceWorkerGlobalScope = ServiceWorkerGlobalScope;
-    this.URL = url.URL || url.parse;
+    this.URL = URL;
 
     // Instance variable to avoid issues with `this`
     this.addEventListener = (name, callback) => {
@@ -72,6 +77,6 @@ class ServiceWorkerGlobalScope {
   }
 }
 
-module.exports = function makeServiceWorkerEnv() {
-  return new ServiceWorkerGlobalScope();
+module.exports = function makeServiceWorkerEnv(envOptions) {
+  return new ServiceWorkerGlobalScope(envOptions);
 };

--- a/packages/service-worker-mock/models/Cache.js
+++ b/packages/service-worker-mock/models/Cache.js
@@ -36,7 +36,10 @@ class Cache {
 
   put(request, response) {
     if (typeof request === 'string') {
+      let relativeUrl = request;
       request = new Request(request);
+      // Add relative url as well
+      this.store.set(relativeUrl, { request, response });
     }
 
     this.store.set(request.url, { request, response });

--- a/packages/service-worker-mock/models/FetchEvent.js
+++ b/packages/service-worker-mock/models/FetchEvent.js
@@ -1,12 +1,13 @@
 const Event = require('./Event');
+const Request = require('./Request');
 
 class FetchEvent extends Event {
   constructor(args) {
     super();
-    if (typeof args === 'string') {
-      this.request = { url: args };
-    } else if (args && typeof args === 'object') {
+    if (args instanceof Request) {
       this.request = args;
+    } else if (typeof args === 'string') {
+      this.request = Request(args);
     }
   }
   respondWith(response) {

--- a/packages/service-worker-mock/models/Request.js
+++ b/packages/service-worker-mock/models/Request.js
@@ -1,9 +1,10 @@
 // stubs https://developer.mozilla.org/en-US/docs/Web/API/Request
 const Headers = require('./Headers');
+const URL = require('dom-urls');
 
 class Request {
   constructor(url, options) {
-    this.url = url || 'http://example.com/some.js';
+    this.url = ((url instanceof URL) ? url : new URL(url, self.location.href)).href;
     this.method = (options && options.method) || 'GET';
     this.mode = (options && options.mode) || 'same-origin';   // FF defaults to cors
     this.headers = (options && options.headers) || new Headers();

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,7 +196,7 @@ aws4@^1.2.1:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.5.0.tgz#0a29ffb79c31c9e712eeb087e8e7a64b4a56d755"
 
-babel-code-frame@^6.16.0, babel-code-frame@^6.20.0:
+babel-code-frame@^6.16.0:
   version "6.20.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.20.0.tgz#b968f839090f9a8bc6d41938fb96cb84f7387b26"
   dependencies:
@@ -204,7 +204,7 @@ babel-code-frame@^6.16.0, babel-code-frame@^6.20.0:
     esutils "^2.0.2"
     js-tokens "^2.0.0"
 
-babel-code-frame@^6.22.0:
+babel-code-frame@^6.20.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
   dependencies:
@@ -828,6 +828,12 @@ doctrine@1.5.0, doctrine@^1.2.2:
   dependencies:
     esutils "^2.0.2"
     isarray "^1.0.0"
+
+dom-urls@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/dom-urls/-/dom-urls-1.1.0.tgz#001ddf81628cd1e706125c7176f53ccec55d918e"
+  dependencies:
+    urijs "^1.16.1"
 
 domain-browser@^1.1.1:
   version "1.1.7"
@@ -3291,6 +3297,10 @@ uid-number@~0.0.6:
 unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+
+urijs@^1.16.1:
+  version "1.19.0"
+  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.0.tgz#d8aa284d0e7469703a6988ad045c4cbfdf08ada0"
 
 url-parse@1.0.x:
   version "1.0.5"


### PR DESCRIPTION
This PR (based on #38) ended up being larger than expected :)

The main difference is that `location` is now an instance of URL. This required changes to `Request`, `FetchEvent` and `Cache`(for relative url matching), and required some updates to the tests that were not using url paths correctly.

It allows manually setting the location for the environment.
```
makeServiceWorkerEnv({ locationUrl, locationBase });
```