### PR TITLE
Update service-worker-mock FetchEvent

### DIFF
--- a/packages/service-worker-mock/models/FetchEvent.js
+++ b/packages/service-worker-mock/models/FetchEvent.js
@@ -2,12 +2,14 @@ const Event = require('./Event');
 const Request = require('./Request');
 
 class FetchEvent extends Event {
-  constructor(args) {
+  constructor(type, init) {
     super();
-    if (args instanceof Request) {
-      this.request = args;
-    } else if (typeof args === 'string') {
-      this.request = Request(args);
+    this.type = type;
+    this.isReload = init.isReload || false;
+    if (init.request instanceof Request) {
+      this.request = init.request;
+    } else if (typeof init.request === 'string') {
+      this.request = Request(init.request);
     }
   }
   respondWith(response) {

--- a/packages/service-worker-mock/utils/eventHandler.js
+++ b/packages/service-worker-mock/utils/eventHandler.js
@@ -6,7 +6,7 @@ const PushEvent = require('../models/PushEvent');
 function createEvent(event, args) {
   switch (event) {
     case 'fetch':
-      return new FetchEvent(args);
+      return new FetchEvent('fetch', { request: args });
     case 'notificationclick':
       return new NotificationEvent(args);
     case 'push':


### PR DESCRIPTION
This PR updates FetchEvent to be inline with the [Spec](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent/FetchEvent). Original issue found here: #52. 