### PR TITLE
 Update service-worker-mock to include reset methods

### DIFF
--- a/packages/service-worker-mock/__tests__/makeServiceWorkerEnv.js
+++ b/packages/service-worker-mock/__tests__/makeServiceWorkerEnv.js
@@ -16,35 +16,39 @@ describe('installation', () => {
     expect(self.location.href).toEqual('https://oh.yeah/scope');
   });
 
-  it('should allow resetting listeners', () => {
-    expect(Object.keys(self.listeners).length).toEqual(0);
-    self.addEventListener('fetch', () => {});
-    expect(Object.keys(self.listeners).length).toEqual(1);
-    self.listeners.reset();
-    expect(Object.keys(self.listeners).length).toEqual(0);
-  });
+  describe('environment resets', () => {
+    Object.assign(global, makeServiceWorkerEnv());
 
-  it('should allow resetting caches', async () => {
-    expect(await self.caches.has('TEST')).toBe(false);
-    self.caches.open('TEST');
-    expect(await self.caches.has('TEST')).toBe(true);
-    self.caches.reset();
-    expect(await self.caches.has('TEST')).toBe(false);
-  });
+    it('should allow resetting listeners', () => {
+      expect(Object.keys(self.listeners).length).toEqual(0);
+      self.addEventListener('fetch', () => {});
+      expect(Object.keys(self.listeners).length).toEqual(1);
+      self.listeners.reset();
+      expect(Object.keys(self.listeners).length).toEqual(0);
+    });
 
-  it('should allow resetting an individual cache', async () => {
-    const testResponse = new Response();
-    const cache = await self.caches.open('TEST');
-    await cache.put(new Request('/'), testResponse);
-    expect(await cache.match(new Request('/'))).toBe(testResponse);
-    cache.reset();
-    expect(await cache.match(new Request('/'))).toBe(null);
-  });
+    it('should allow resetting caches', async () => {
+      expect(await self.caches.has('TEST')).toBe(false);
+      await self.caches.open('TEST');
+      expect(await self.caches.has('TEST')).toBe(true);
+      self.caches.reset();
+      expect(await self.caches.has('TEST')).toBe(false);
+    });
 
-  it('should allow resetting clients', async () => {
-    const client = await self.clients.openWindow('/');
-    expect(await clients.get(client.id)).toBe(client);
-    clients.reset();
-    expect(await clients.get(client.id)).toBe(null);
+    it('should allow resetting an individual cache', async () => {
+      const testResponse = new Response();
+      const cache = await self.caches.open('TEST');
+      await cache.put(new Request('/'), testResponse);
+      expect(await cache.match(new Request('/'))).toBe(testResponse);
+      cache.reset();
+      expect(await cache.match(new Request('/'))).toBe(null);
+    });
+
+    it('should allow resetting clients', async () => {
+      const client = await self.clients.openWindow('/');
+      expect(await clients.get(client.id)).toBe(client);
+      clients.reset();
+      expect(await clients.get(client.id)).toBe(null);
+    });
   });
 });

--- a/packages/service-worker-mock/__tests__/makeServiceWorkerEnv.js
+++ b/packages/service-worker-mock/__tests__/makeServiceWorkerEnv.js
@@ -50,5 +50,19 @@ describe('installation', () => {
       clients.reset();
       expect(await clients.get(client.id)).toBe(null);
     });
+
+    it('should allow resetting everything', async () => {
+      self.addEventListener('fetch', () => {});
+      await self.caches.open('TEST');
+      const client = await self.clients.openWindow('/');
+
+      expect(Object.keys(self.listeners).length).toEqual(1);
+      expect(await self.caches.has('TEST')).toBe(true);
+      expect(await clients.get(client.id)).toBe(client);
+      self.resetSwEnv();
+      expect(Object.keys(self.listeners).length).toEqual(0);
+      expect(await self.caches.has('TEST')).toBe(false);
+      expect(await clients.get(client.id)).toBe(null);
+    });
   });
 });

--- a/packages/service-worker-mock/__tests__/makeServiceWorkerEnv.js
+++ b/packages/service-worker-mock/__tests__/makeServiceWorkerEnv.js
@@ -15,4 +15,36 @@ describe('installation', () => {
     expect(self.location instanceof URL).toBe(true);
     expect(self.location.href).toEqual('https://oh.yeah/scope');
   });
+
+  it('should allow resetting listeners', () => {
+    expect(Object.keys(self.listeners).length).toEqual(0);
+    self.addEventListener('fetch', () => {});
+    expect(Object.keys(self.listeners).length).toEqual(1);
+    self.listeners.reset();
+    expect(Object.keys(self.listeners).length).toEqual(0);
+  });
+
+  it('should allow resetting caches', async () => {
+    expect(await self.caches.has('TEST')).toBe(false);
+    self.caches.open('TEST');
+    expect(await self.caches.has('TEST')).toBe(true);
+    self.caches.reset();
+    expect(await self.caches.has('TEST')).toBe(false);
+  });
+
+  it('should allow resetting an individual cache', async () => {
+    const testResponse = new Response();
+    const cache = await self.caches.open('TEST');
+    await cache.put(new Request('/'), testResponse);
+    expect(await cache.match(new Request('/'))).toBe(testResponse);
+    cache.reset();
+    expect(await cache.match(new Request('/'))).toBe(null);
+  });
+
+  it('should allow resetting clients', async () => {
+    const client = await self.clients.openWindow('/');
+    expect(await clients.get(client.id)).toBe(client);
+    clients.reset();
+    expect(await clients.get(client.id)).toBe(null);
+  });
 });

--- a/packages/service-worker-mock/index.js
+++ b/packages/service-worker-mock/index.js
@@ -24,10 +24,21 @@ const defaults = (envOptions) => Object.assign({
   locationUrl: 'https://www.test.com'
 }, envOptions);
 
+const makeListenersWithReset = () => {
+  const listeners = {};
+  Object.defineProperty(listeners, 'reset', {
+    enumerable: false,
+    value: () => {
+      self.listeners = makeListenersWithReset();
+    }
+  });
+  return listeners;
+};
+
 class ServiceWorkerGlobalScope {
   constructor(envOptions) {
     const options = defaults(envOptions);
-    this.listeners = {};
+    this.listeners = makeListenersWithReset();
     this.location = new URL(options.locationUrl, options.locationBase);
     this.skipWaiting = () => Promise.resolve();
     this.caches = new CacheStorage();
@@ -76,6 +87,13 @@ class ServiceWorkerGlobalScope {
         clients: this.clients.snapshot(),
         notifications: this.registration.snapshot()
       };
+    };
+
+    // Allow resetting without rewriting
+    this.resetSwEnv = () => {
+      this.caches.reset();
+      this.clients.reset();
+      this.listeners = {};
     };
 
     this.self = this;

--- a/packages/service-worker-mock/index.js
+++ b/packages/service-worker-mock/index.js
@@ -93,7 +93,7 @@ class ServiceWorkerGlobalScope {
     this.resetSwEnv = () => {
       this.caches.reset();
       this.clients.reset();
-      this.listeners = {};
+      this.listeners.reset();
     };
 
     this.self = this;

--- a/packages/service-worker-mock/models/Cache.js
+++ b/packages/service-worker-mock/models/Cache.js
@@ -68,6 +68,10 @@ class Cache {
     }
     return snapshot;
   }
+
+  reset() {
+    this.store = new Map();
+  }
 }
 
 module.exports = Cache;

--- a/packages/service-worker-mock/models/CacheStorage.js
+++ b/packages/service-worker-mock/models/CacheStorage.js
@@ -47,6 +47,10 @@ class CacheStorage {
       return obj;
     }, {});
   }
+
+  reset() {
+    this.caches = {};
+  }
 }
 
 module.exports = CacheStorage;

--- a/packages/service-worker-mock/models/Clients.js
+++ b/packages/service-worker-mock/models/Clients.js
@@ -29,6 +29,9 @@ class Clients {
     return this.clients.map(client => client.snapshot());
   }
 
+  reset() {
+    this.clients = [];
+  }
 }
 
 module.exports = Clients;


### PR DESCRIPTION
This is a feature request from #62. It adds the ability to reset the environment.

```js
self.resetSwEnv();
self.listeners.reset();
self.caches.reset();
(await self.caches.open(key)).reset();
self.clients.reset();
```