### PR TITLE
Handle 'message' events

### DIFF
--- a/packages/service-worker-mock/index.js
+++ b/packages/service-worker-mock/index.js
@@ -20,6 +20,7 @@ const PushSubscription = require('./models/PushSubscription');
 const Request = require('./models/Request');
 const Response = require('./models/Response');
 const ServiceWorkerRegistration = require('./models/ServiceWorkerRegistration');
+const MessageEvent = require('./models/MessageEvent');
 
 const eventHandler = require('./utils/eventHandler');
 
@@ -66,6 +67,7 @@ class ServiceWorkerGlobalScope {
     this.Response = Response;
     this.ServiceWorkerGlobalScope = ServiceWorkerGlobalScope;
     this.URL = URL;
+    this.MessageEvent = MessageEvent;
 
     // Instance variable to avoid issues with `this`
     this.addEventListener = (name, callback) => {

--- a/packages/service-worker-mock/models/MessageEvent.js
+++ b/packages/service-worker-mock/models/MessageEvent.js
@@ -1,0 +1,10 @@
+const ExtendableEvent = require('./ExtendableEvent');
+
+class MessageEvent extends ExtendableEvent {
+  constructor(type, args) {
+    super();
+    Object.assign(this, args);
+  }
+}
+
+module.exports = MessageEvent;

--- a/packages/service-worker-mock/utils/eventHandler.js
+++ b/packages/service-worker-mock/utils/eventHandler.js
@@ -2,6 +2,7 @@ const ExtendableEvent = require('../models/ExtendableEvent');
 const FetchEvent = require('../models/FetchEvent');
 const NotificationEvent = require('../models/NotificationEvent');
 const PushEvent = require('../models/PushEvent');
+const MessageEvent = require('../models/MessageEvent');
 
 function createEvent(event, args) {
   switch (event) {
@@ -11,6 +12,8 @@ function createEvent(event, args) {
       return new NotificationEvent(args);
     case 'push':
       return new PushEvent(args);
+    case 'message':
+      return new MessageEvent('message', args);
     default:
       return new ExtendableEvent();
   }


### PR DESCRIPTION
This adds a new `MessageEvent` model that is used to handle events of type `message`. These events can be triggered on a worker by using the workers `postMessage` API.