### PR TITLE
Headers.get() should return null when the header doesn't exist.

### DIFF
--- a/packages/service-worker-mock/__tests__/Headers.js
+++ b/packages/service-worker-mock/__tests__/Headers.js
@@ -3,7 +3,7 @@ const Headers = require('../models/Headers');
 describe('Headers', () => {
   it('should construct with no defaults', () => {
     const headers = new Headers();
-    expect(headers.get('accept')).toEqual('');
+    expect(headers.get('accept')).toEqual(null);
   });
 
   it('should construct with Header instance', () => {

--- a/packages/service-worker-mock/models/Headers.js
+++ b/packages/service-worker-mock/models/Headers.js
@@ -27,7 +27,7 @@ class Headers {
   }
 
   get(name) {
-    return this._map.get(name) || '';
+    return this._map.has(name) ? this._map.get(name) : null;
   }
 
   has(name) {


### PR DESCRIPTION
As per https://fetch.spec.whatwg.org/#dom-headers-get

(Related: https://github.com/GoogleChrome/workbox/pull/1422)