### PR TITLE
fix(service-workers-mock): fetch.js was not published

### DIFF
--- a/packages/service-worker-mock/package.json
+++ b/packages/service-worker-mock/package.json
@@ -8,6 +8,7 @@
   },
   "files": [
     "index.js",
+    "fetch.js",
     "utils",
     "models"
   ],


### PR DESCRIPTION
Following the readme (`const makeFetchMock = require('service-worker-mock/fetch');`) would result in an error because the file was not published.