### PR TITLE
Bugfix - fix triggering a fetch event with a string

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 packages/service-worker-plugin/runtime.js
+packages/service-worker-mock/node_modules

--- a/packages/service-worker-mock/__tests__/FetchEvent.js
+++ b/packages/service-worker-mock/__tests__/FetchEvent.js
@@ -1,0 +1,22 @@
+const makeServiceWorkerEnv = require('../index');
+const FetchEvent = require('../models/FetchEvent');
+
+describe('FetchEvent', () => {
+  it('should construct with Request', () => {
+    Object.assign(global, makeServiceWorkerEnv());
+
+    const request = new Request('/test');
+    const event = new FetchEvent('fetch', { request });
+
+    expect(event.request.url).toEqual('https://www.test.com/test');
+  });
+
+  it('should construct with string', () => {
+    Object.assign(global, makeServiceWorkerEnv());
+
+    const request = '/test';
+    const event = new FetchEvent('fetch', { request });
+
+    expect(event.request.url).toEqual('https://www.test.com/test');
+  });
+});

--- a/packages/service-worker-mock/models/FetchEvent.js
+++ b/packages/service-worker-mock/models/FetchEvent.js
@@ -9,7 +9,7 @@ class FetchEvent extends ExtendableEvent {
     if (init.request instanceof Request) {
       this.request = init.request;
     } else if (typeof init.request === 'string') {
-      this.request = Request(init.request);
+      this.request = new Request(init.request);
     }
   }
   respondWith(response) {


### PR DESCRIPTION
When using `service-worker-mock`, I found that triggering a fetch event with a string would fail with error: 
```
TypeError: Class constructor Request cannot be invoked without 'new'
```
This PR fixes the error.

* Fix triggering a fetch event with a string
    * Triggering a `fetch` event with a string was not working properly because it was not calling the constructor with `new`
* Fixed eslint
    * Lint was being called on the nested `node_modules` in `service-worker-mock`