### PR TITLE
Response extends body

### DIFF
--- a/packages/service-worker-mock/__tests__/ServiceWorkerGlobalScope.js
+++ b/packages/service-worker-mock/__tests__/ServiceWorkerGlobalScope.js
@@ -36,7 +36,7 @@ describe('installation', () => {
     });
 
     it('should allow resetting an individual cache', async () => {
-      const testResponse = new Response(null);
+      const testResponse = new Response();
       const cache = await self.caches.open('TEST');
       await cache.put(new Request('/'), testResponse);
       expect(await cache.match(new Request('/'))).toBe(testResponse);

--- a/packages/service-worker-mock/__tests__/ServiceWorkerGlobalScope.js
+++ b/packages/service-worker-mock/__tests__/ServiceWorkerGlobalScope.js
@@ -36,7 +36,7 @@ describe('installation', () => {
     });
 
     it('should allow resetting an individual cache', async () => {
-      const testResponse = new Response();
+      const testResponse = new Response(null);
       const cache = await self.caches.open('TEST');
       await cache.put(new Request('/'), testResponse);
       expect(await cache.match(new Request('/'))).toBe(testResponse);

--- a/packages/service-worker-mock/models/Body.js
+++ b/packages/service-worker-mock/models/Body.js
@@ -18,11 +18,11 @@ class Body {
   }
 
   json() {
-    return this.resolve('json', body => JSON.parse(body._text));
+    return this.resolve('json', body => JSON.parse(body.text));
   }
 
   text() {
-    return this.resolve('text', body => body._text);
+    return this.resolve('text', body => body.text);
   }
 
   resolve(name, resolver) {

--- a/packages/service-worker-mock/models/Body.js
+++ b/packages/service-worker-mock/models/Body.js
@@ -7,22 +7,22 @@ const throwBodyUsed = (method) => {
 class Body {
   constructor(body) {
     this.bodyUsed = false;
-    this.body = new Blob([body]);
+    this.body = body instanceof Blob ? body : new Blob([body]);
   }
   arrayBuffer() {
     throw new Error('Body.arrayBuffer is not yet supported.');
   }
 
   blob() {
-    this.resolve('json', body => new Blob([body]));
+    return this.resolve('blob', body => new Blob([body]));
   }
 
   json() {
-    this.resolve('json', body => JSON.parse(body._text));
+    return this.resolve('json', body => JSON.parse(body._text));
   }
 
   text() {
-    this.resolve('json', body => body._text);
+    return this.resolve('text', body => body._text);
   }
 
   resolve(name, resolver) {

--- a/packages/service-worker-mock/models/Body.js
+++ b/packages/service-worker-mock/models/Body.js
@@ -26,7 +26,7 @@ class Body {
   }
 
   resolve(name, resolver) {
-    if (this.bodyUsed) throwBodyUsed('text');
+    if (this.bodyUsed) throwBodyUsed(name);
     this.bodyUsed = true;
     return Promise.resolve(resolver(this.body));
   }

--- a/packages/service-worker-mock/models/Response.js
+++ b/packages/service-worker-mock/models/Response.js
@@ -7,7 +7,7 @@ const isSupportedBodyType = (body) =>
   (typeof body === 'string');
 
 class Response extends Body {
-  constructor(body, init) {
+  constructor(body = null, init) {
     if (!isSupportedBodyType(body)) {
       throw new TypeError('Response body must be one of: Blob, USVString, null');
     }

--- a/packages/service-worker-mock/models/Response.js
+++ b/packages/service-worker-mock/models/Response.js
@@ -1,15 +1,8 @@
 // stubs https://developer.mozilla.org/en-US/docs/Web/API/Response
 const Body = require('./Body');
 
-const isSupportedBodyType = (body) =>
-  (body instanceof Blob) ||
-  (typeof body === 'string');
-
 class Response extends Body {
   constructor(body, init) {
-    if (!isSupportedBodyType(body)) {
-      body = JSON.stringify(body);
-    }
     super(body);
     this.status = (init && typeof init.status === 'number') ? init.status : 200;
     this.ok = this.status >= 200 && this.status < 300;

--- a/packages/service-worker-mock/models/Response.js
+++ b/packages/service-worker-mock/models/Response.js
@@ -1,7 +1,16 @@
 // stubs https://developer.mozilla.org/en-US/docs/Web/API/Response
-class Response {
+const Body = require('./Body');
+
+const isSupportedBodyType = (body) =>
+  (body instanceof Blob) ||
+  (typeof body === 'string');
+
+class Response extends Body {
   constructor(body, init) {
-    this.body = body || '';
+    if (!isSupportedBodyType(body)) {
+      body = JSON.stringify(body);
+    }
+    super(body);
     this.status = (init && typeof init.status === 'number') ? init.status : 200;
     this.ok = this.status >= 200 && this.status < 300;
     this.statusText = (init && init.statusText) || 'OK';
@@ -19,14 +28,6 @@ class Response {
       headers: this.headers,
       url: this.url
     });
-  }
-
-  text() {
-    try {
-      return Promise.resolve(this.body.toString());
-    } catch (err) {
-      return Promise.resolve(Object.prototype.toString.apply(this.body));
-    }
   }
 }
 

--- a/packages/service-worker-mock/models/Response.js
+++ b/packages/service-worker-mock/models/Response.js
@@ -2,13 +2,14 @@
 const Body = require('./Body');
 
 const isSupportedBodyType = (body) =>
+  (body === null) ||
   (body instanceof Blob) ||
   (typeof body === 'string');
 
 class Response extends Body {
   constructor(body, init) {
     if (!isSupportedBodyType(body)) {
-      throw new TypeError('Response requires a Blob or USVString');
+      throw new TypeError('Response body must be one of: Blob, USVString, null');
     }
     super(body);
     this.status = (init && typeof init.status === 'number') ? init.status : 200;

--- a/packages/service-worker-mock/models/Response.js
+++ b/packages/service-worker-mock/models/Response.js
@@ -1,8 +1,15 @@
 // stubs https://developer.mozilla.org/en-US/docs/Web/API/Response
 const Body = require('./Body');
 
+const isSupportedBodyType = (body) =>
+  (body instanceof Blob) ||
+  (typeof body === 'string');
+
 class Response extends Body {
   constructor(body, init) {
+    if (!isSupportedBodyType(body)) {
+      throw new TypeError('Response requires a Blob or USVString');
+    }
     super(body);
     this.status = (init && typeof init.status === 'number') ? init.status : 200;
     this.ok = this.status >= 200 && this.status < 300;


### PR DESCRIPTION
Making Response extend Body and using its resolver methods. The only backwards incompatible change is throwing for unsupported response types.