### PR TITLE
Support "notificationclose" event in mock

### DIFF
--- a/packages/service-worker-mock/utils/eventHandler.js
+++ b/packages/service-worker-mock/utils/eventHandler.js
@@ -9,6 +9,7 @@ function createEvent(event, args) {
     case 'fetch':
       return new FetchEvent('fetch', { request: args });
     case 'notificationclick':
+    case 'notificationclose':
       return new NotificationEvent(args);
     case 'push':
       return new PushEvent(args);


### PR DESCRIPTION
As title, mock notification closed event in service-worker-mock.

```
self.addEventListener('notificationclose', function(NotificationEvent) {
    ...
});
```
https://developer.mozilla.org/en-US/docs/Web/API/ServiceWorkerGlobalScope/onnotificationclose