### PR TITLE
Mock WindowClient interface

### DIFF
--- a/packages/service-worker-mock/index.js
+++ b/packages/service-worker-mock/index.js
@@ -8,6 +8,7 @@ const Body = require('./models/Body');
 const Cache = require('./models/Cache');
 const CacheStorage = require('./models/CacheStorage');
 const Client = require('./models/Client');
+const WindowClient = require('./models/WindowClient');
 const Clients = require('./models/Clients');
 const ExtendableEvent = require('./models/ExtendableEvent');
 const FetchEvent = require('./models/FetchEvent');
@@ -54,6 +55,7 @@ class ServiceWorkerGlobalScope {
     this.Body = Body;
     this.Cache = Cache;
     this.Client = Client;
+    this.WindowClient = WindowClient;
     this.Event = ExtendableEvent;
     this.ExtendableEvent = ExtendableEvent;
     this.FetchEvent = FetchEvent;

--- a/packages/service-worker-mock/models/Client.js
+++ b/packages/service-worker-mock/models/Client.js
@@ -2,9 +2,10 @@ const generateRandomId = require('../utils/generateRandomId');
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Client
 class Client {
-  constructor(url, frameType) {
+  constructor(url, type, frameType) {
     this.id = generateRandomId();
     this.url = url;
+    this.type = type || 'worker';
     this.frameType = frameType;
   }
 
@@ -15,6 +16,7 @@ class Client {
   snapshot() {
     return {
       url: this.url,
+      type: this.type,
       frameType: this.frameType
     };
   }

--- a/packages/service-worker-mock/models/Clients.js
+++ b/packages/service-worker-mock/models/Clients.js
@@ -1,4 +1,4 @@
-const Client = require('./Client');
+const WindowClient = require('./WindowClient');
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Clients
 class Clients {
@@ -16,9 +16,9 @@ class Clients {
   }
 
   openWindow(url) {
-    const client = new Client(url);
-    this.clients.push(client);
-    return Promise.resolve(client);
+    const windowClient = new WindowClient(url);
+    this.clients.push(windowClient);
+    return Promise.resolve(windowClient);
   }
 
   claim() {

--- a/packages/service-worker-mock/models/WindowClient.js
+++ b/packages/service-worker-mock/models/WindowClient.js
@@ -1,0 +1,23 @@
+const Client = require('./Client');
+
+// https://developer.mozilla.org/en-US/docs/Web/API/WindowClient
+class WindowClient extends Client {
+  constructor(args) {
+    super(...args);
+
+    this.type = 'window';
+    this.focused = false;
+  }
+
+  focus() {
+    this.focused = true;
+    return Promise.resolve(this);
+  }
+
+  navigate(url) {
+    this.url = url;
+    return Promise.resolve(this);
+  }
+}
+
+module.exports = WindowClient;


### PR DESCRIPTION
- Mock [`WindowClient`](https://developer.mozilla.org/en-US/docs/Web/API/WindowClient) which inherited from `Client` model.
- Clients's `openWindow()` method should append `WindowClient` into list, instead of `Client`.