### PR TITLE
Fix regression in WindowClient

### DIFF
--- a/packages/service-worker-mock/__tests__/Clients.js
+++ b/packages/service-worker-mock/__tests__/Clients.js
@@ -23,6 +23,19 @@ describe('Clients', () => {
     expect(expectedClient.id).toBe(CLIENT_FIXTURES[0].id);
   });
 
+  it('should get array of matched clients', async () => {
+    const clients = new Clients();
+    clients.clients = CLIENT_FIXTURES;
+
+    // Without options
+    let matchedClients = await clients.matchAll();
+    expect(matchedClients).toHaveLength(3);
+
+    // Get specific client by type
+    matchedClients = await clients.matchAll({ type: 'sharedworker' });
+    expect(matchedClients).toHaveLength(1);
+  });
+
   it('should able to open a new window', async () => {
     const clients = new Clients();
     await clients.openWindow('https://www.abc.com');

--- a/packages/service-worker-mock/__tests__/Clients.js
+++ b/packages/service-worker-mock/__tests__/Clients.js
@@ -1,0 +1,33 @@
+const makeServiceWorkerEnv = require('../index');
+const Clients = require('../models/Clients');
+const Client = require('../models/Client');
+const WindowClient = require('../models/WindowClient');
+
+const CLIENT_FIXTURES = [
+  new Client('/'),
+  new Client('/', 'sharedworker'),
+  new WindowClient('https://www.abc.com')
+];
+
+describe('Clients', () => {
+  beforeEach(() => {
+    Object.assign(global, makeServiceWorkerEnv());
+    jest.resetModules();
+  });
+
+  it('should get client by id', async () => {
+    const clients = new Clients();
+    clients.clients = CLIENT_FIXTURES;
+
+    const expectedClient = await clients.get(CLIENT_FIXTURES[0].id);
+    expect(expectedClient.id).toBe(CLIENT_FIXTURES[0].id);
+  });
+
+  it('should able to open a new window', async () => {
+    const clients = new Clients();
+    await clients.openWindow('https://www.abc.com');
+
+    expect(clients.snapshot()).toHaveLength(1);
+    expect(clients.snapshot()[0].url).toBe('https://www.abc.com');
+  });
+});

--- a/packages/service-worker-mock/models/Clients.js
+++ b/packages/service-worker-mock/models/Clients.js
@@ -11,8 +11,12 @@ class Clients {
     return Promise.resolve(client || null);
   }
 
-  matchAll() {
-    return Promise.resolve(this.clients);
+  matchAll({ type = 'all' } = {}) {
+    if (type === 'all') {
+      return Promise.resolve(this.clients);
+    }
+    const matchedClients = this.clients.filter(client => client.type === type);
+    return Promise.resolve(matchedClients);
   }
 
   openWindow(url) {

--- a/packages/service-worker-mock/models/WindowClient.js
+++ b/packages/service-worker-mock/models/WindowClient.js
@@ -2,7 +2,7 @@ const Client = require('./Client');
 
 // https://developer.mozilla.org/en-US/docs/Web/API/WindowClient
 class WindowClient extends Client {
-  constructor(args) {
+  constructor(...args) {
     super(...args);
 
     this.type = 'window';


### PR DESCRIPTION
I'm sorry that made a stupid regression in #95.
Arguments in `WindowClient` constructor should be iterable before passing to `Client` instance. 

Added new unit testcase to verify the expected result and added matching options in `matchAll()` method that you mentioned in previous PR.