### PR TITLE
feat(Response) Add `Response.error()`

### DIFF
--- a/packages/service-worker-mock/__tests__/Response.js
+++ b/packages/service-worker-mock/__tests__/Response.js
@@ -1,0 +1,10 @@
+const Response = require('../models/Response');
+
+describe('Response', () => {
+    it('should create an error Response', () => {
+        const response = Response.error();
+        expect(response.type).toEqual('error');
+        expect(response.body).toBeNull();
+        expect(response.status).toEqual(0);
+    });
+});

--- a/packages/service-worker-mock/models/Body.js
+++ b/packages/service-worker-mock/models/Body.js
@@ -7,7 +7,7 @@ const throwBodyUsed = (method) => {
 class Body {
   constructor(body) {
     this.bodyUsed = false;
-    this.body = body instanceof Blob ? body : new Blob([body]);
+    this.body = body === null || body instanceof Blob ? body : new Blob([body]);
   }
   arrayBuffer() {
     throw new Error('Body.arrayBuffer is not yet supported.');

--- a/packages/service-worker-mock/models/Response.js
+++ b/packages/service-worker-mock/models/Response.js
@@ -30,6 +30,18 @@ class Response extends Body {
       url: this.url
     });
   }
+
+  static error() {
+    const errorResponse = new Response(null, {
+      url: '',
+      headers: {},
+      status: 0
+    });
+
+    errorResponse.type = 'error';
+
+    return errorResponse;
+  }
 }
 
 module.exports = Response;


### PR DESCRIPTION
- Adds `Response.error()`
- https://developer.mozilla.org/en-US/docs/Web/API/Response/error