### PR TITLE
fix(service-worker-mock) Make header names case-insensitive

### DIFF
--- a/packages/service-worker-mock/__tests__/Headers.js
+++ b/packages/service-worker-mock/__tests__/Headers.js
@@ -18,6 +18,18 @@ describe('Headers', () => {
     expect(headers.get('accept')).toEqual('*/*');
   });
 
+  it('should ignore character case', () => {
+    const headers = new Headers();
+    headers.set('UPPER', 'UPPER');
+    expect(headers.get('upper')).toEqual('UPPER');
+
+    headers.append('UPPER', 'CASE');
+    expect(headers.get('upper')).toEqual('UPPER,CASE');
+
+    headers.delete('UPPER');
+    expect(headers.get('upper')).toEqual(null);
+  });
+
   it('should append values', () => {
     const headers = new Headers();
     headers.append('accept', 'application/json');

--- a/packages/service-worker-mock/models/Headers.js
+++ b/packages/service-worker-mock/models/Headers.js
@@ -12,14 +12,14 @@ class Headers {
   }
 
   append(name, value) {
-    if (this._map.has(name)) {
-      value = `${this._map.get(name)},${value}`;
+    if (this._map.has(name.toLowerCase())) {
+      value = `${this._map.get(name.toLowerCase())},${value}`;
     }
-    this._map.set(name, value);
+    this._map.set(name.toLowerCase(), value);
   }
 
   delete(name) {
-    this._map.delete(name);
+    this._map.delete(name.toLowerCase());
   }
 
   entries() {
@@ -31,11 +31,11 @@ class Headers {
   }
 
   get(name) {
-    return this._map.has(name) ? this._map.get(name) : null;
+    return this._map.has(name.toLowerCase()) ? this._map.get(name.toLowerCase()) : null;
   }
 
   has(name) {
-    return this._map.has(name);
+    return this._map.has(name.toLowerCase());
   }
 
   keys() {
@@ -43,7 +43,7 @@ class Headers {
   }
 
   set(name, value) {
-    this._map.set(name, value);
+    this._map.set(name.toLowerCase(), value);
   }
 
   values() {


### PR DESCRIPTION
Sets all header names to lowercase.

See: https://developer.mozilla.org/en-US/docs/Web/API/Headers/get