### PR TITLE
add action to NotificationEvent

### DIFF
--- a/packages/service-worker-mock/__tests__/NotificationEvent.js
+++ b/packages/service-worker-mock/__tests__/NotificationEvent.js
@@ -1,34 +1,35 @@
 const makeServiceWorkerEnv = require('../index');
+const NotificationEvent = require('../models/NotificationEvent');
 
 describe('NotificationEvent', () => {
-    beforeEach(() => {
-        Object.assign(global, makeServiceWorkerEnv());
-        jest.resetModules();
-    });
+  beforeEach(() => {
+    Object.assign(global, makeServiceWorkerEnv());
+    jest.resetModules();
+  });
 
-    it('should properly initialize notification from args or args.notificaiton', () => {
-        const args = {
-            data: 'Test data'
-        };
+  it('should properly initialize notification from args or args.notificaiton', () => {
+    const args = {
+      data: 'Test data'
+    };
 
-        const event = new NotificationEvent(args)
-        expect(event.notification.data).toEqual(args.data)
+    const event = new NotificationEvent(args);
+    expect(event.notification.data).toEqual(args.data);
 
-        const args2 = {
-            notification: { data: 'Test data 2' }
-        };
+    const args2 = {
+      notification: { data: 'Test data 2' }
+    };
 
-        const event2 = new NotificationEvent(args2)
-        expect(event2.notification.data).toEqual(args2.notification.data)
-    });
+    const event2 = new NotificationEvent(args2);
+    expect(event2.notification.data).toEqual(args2.notification.data);
+  });
 
-    it('should properly initialize action', () => {
-        const args = {
-            action: 'test-action',
-            notification: { data: 'Test data' }
-        };
+  it('should properly initialize action', () => {
+    const args = {
+      action: 'test-action',
+      notification: { data: 'Test data' }
+    };
 
-        const event = new NotificationEvent(args)
-        expect(event.action).toEqual(args.action)
-    });
+    const event = new NotificationEvent(args);
+    expect(event.action).toEqual(args.action);
+  });
 });

--- a/packages/service-worker-mock/__tests__/NotificationEvent.js
+++ b/packages/service-worker-mock/__tests__/NotificationEvent.js
@@ -1,0 +1,34 @@
+const makeServiceWorkerEnv = require('../index');
+
+describe('NotificationEvent', () => {
+    beforeEach(() => {
+        Object.assign(global, makeServiceWorkerEnv());
+        jest.resetModules();
+    });
+
+    it('should properly initialize notification from args or args.notificaiton', () => {
+        const args = {
+            data: 'Test data'
+        };
+
+        const event = new NotificationEvent(args)
+        expect(event.notification.data).toEqual(args.data)
+
+        const args2 = {
+            notification: { data: 'Test data 2' }
+        };
+
+        const event2 = new NotificationEvent(args2)
+        expect(event2.notification.data).toEqual(args2.notification.data)
+    });
+
+    it('should properly initialize action', () => {
+        const args = {
+            action: 'test-action',
+            notification: { data: 'Test data' }
+        };
+
+        const event = new NotificationEvent(args)
+        expect(event.action).toEqual(args.action)
+    });
+});

--- a/packages/service-worker-mock/__tests__/NotificationEvent.js
+++ b/packages/service-worker-mock/__tests__/NotificationEvent.js
@@ -7,29 +7,21 @@ describe('NotificationEvent', () => {
     jest.resetModules();
   });
 
-  it('should properly initialize notification from args or args.notificaiton', () => {
-    const args = {
-      data: 'Test data'
-    };
-
-    const event = new NotificationEvent(args);
-    expect(event.notification.data).toEqual(args.data);
-
-    const args2 = {
-      notification: { data: 'Test data 2' }
-    };
-
-    const event2 = new NotificationEvent(args2);
-    expect(event2.notification.data).toEqual(args2.notification.data);
-  });
-
-  it('should properly initialize action', () => {
-    const args = {
-      action: 'test-action',
+  it('should properly initialize notification from initial data', () => {
+    const init = {
       notification: { data: 'Test data' }
     };
 
-    const event = new NotificationEvent(args);
-    expect(event.action).toEqual(args.action);
+    const event = new NotificationEvent('notification', init);
+    expect(event.notification.data).toEqual(init.notification.data);
+  });
+
+  it('should properly initialize action', () => {
+    const init = {
+      action: 'test-action'
+    };
+
+    const event = new NotificationEvent('notification', init);
+    expect(event.action).toEqual(init.action);
   });
 });

--- a/packages/service-worker-mock/models/MessagePort.js
+++ b/packages/service-worker-mock/models/MessagePort.js
@@ -35,7 +35,7 @@ class MessagePort extends EventTarget {
    * could not be cloned.
    * TODO: Implement Transferable
    */
-  postMessage(message /* , transfer?: Transferable[]*/) {
+  postMessage(message /* , transfer?: Transferable[] */) {
     const event = new MessageEvent('message', {
       data: message
     });

--- a/packages/service-worker-mock/models/NotificationEvent.js
+++ b/packages/service-worker-mock/models/NotificationEvent.js
@@ -5,7 +5,7 @@ class NotificationEvent extends ExtendableEvent {
   constructor(args) {
     super();
     this.notification = args.notification || args;
-    this.action = args.action
+    this.action = args.action;
   }
 }
 

--- a/packages/service-worker-mock/models/NotificationEvent.js
+++ b/packages/service-worker-mock/models/NotificationEvent.js
@@ -4,7 +4,8 @@ const ExtendableEvent = require('./ExtendableEvent');
 class NotificationEvent extends ExtendableEvent {
   constructor(args) {
     super();
-    this.notification = args;
+    this.notification = args.notification || args;
+    this.action = args.action
   }
 }
 

--- a/packages/service-worker-mock/models/NotificationEvent.js
+++ b/packages/service-worker-mock/models/NotificationEvent.js
@@ -2,10 +2,10 @@ const ExtendableEvent = require('./ExtendableEvent');
 
 // https://developer.mozilla.org/en-US/docs/Web/API/NotificationEvent
 class NotificationEvent extends ExtendableEvent {
-  constructor(args) {
-    super();
-    this.notification = args.notification || args;
-    this.action = args.action;
+  constructor(type, init) {
+    super(type, init);
+    this.notification = init ? init.notification : null;
+    this.action = init ? init.action : null;
   }
 }
 

--- a/packages/service-worker-mock/models/ServiceWorkerRegistration.js
+++ b/packages/service-worker-mock/models/ServiceWorkerRegistration.js
@@ -33,7 +33,7 @@ class ServiceWorkerRegistration extends EventTarget {
       const index = this.notifications.indexOf(notification);
       this.notifications.splice(index, 1);
     };
-    return Promise.resolve(new NotificationEvent(notification));
+    return Promise.resolve(new NotificationEvent('notification', { notification }));
   }
 
   update() {

--- a/packages/service-worker-mock/package.json
+++ b/packages/service-worker-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-worker-mock",
-  "version": "3.0.0",
+  "version": "2.0.3",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/packages/service-worker-mock/package.json
+++ b/packages/service-worker-mock/package.json
@@ -1,6 +1,6 @@
 {
   "name": "service-worker-mock",
-  "version": "2.0.3",
+  "version": "3.0.0",
   "main": "index.js",
   "repository": {
     "type": "git",

--- a/packages/service-worker-mock/utils/eventHandler.js
+++ b/packages/service-worker-mock/utils/eventHandler.js
@@ -10,7 +10,7 @@ function createEvent(event, args) {
       return new FetchEvent('fetch', { request: args });
     case 'notificationclick':
     case 'notificationclose':
-      return new NotificationEvent(args);
+      return new NotificationEvent('notification', { notification: args });
     case 'push':
       return new PushEvent(args);
     case 'message':


### PR DESCRIPTION
according to https://developer.mozilla.org/en-US/docs/Web/API/NotificationEvent `NotificationEvent` should have an `action` property. This should be backwards compatible with how it was before.