### PR TITLE
Fix webpack v4 deprecation warning

### DIFF
--- a/packages/service-worker-plugin/index.js
+++ b/packages/service-worker-plugin/index.js
@@ -23,7 +23,7 @@ ProgressiveWebappPlugin.prototype.apply = function (compiler) {
   fs.writeFileSync(runtimePath, generatedRuntime);
 
   // Generate service workers
-  compiler.plugin('emit', (compilation, callback) => {
+  const emit = (compilation, callback) => {
     const assets = compilation.assets;
     // Update configs with matched precache asset paths
     const baseConfigWithPrecache = mapPrecacheAssets(assets, this.baseConfig, publicPath);
@@ -52,7 +52,13 @@ ProgressiveWebappPlugin.prototype.apply = function (compiler) {
     });
 
     callback();
-  });
+  };
+  if (compiler.hooks) {
+    const plugin = { name: 'ServiceWorkerPlugin' };
+    compiler.hooks.emit.tap(plugin, emit);
+  } else {
+    compiler.plugin('emit', emit);
+  }
 };
 
 module.exports = ProgressiveWebappPlugin;


### PR DESCRIPTION
`Tapable.plugin` is deprecated in webpack v4. Converted the plug-in to use hooks when they are available.

```
(node:1222) DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead
    at ProgressiveWebappPlugin.apply (/mnt/pinboard/webapp/node_modules/service-worker-plugin/index.js:26:12)
    at webpack (/mnt/pinboard/webapp/node_modules/webpack/lib/webpack.js:47:13)
    at Object.<anonymous> (/mnt/pinboard/webapp/startWebpackDevServer.js:10:16)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Function.Module.runMain (module.js:694:10)
    at startup (bootstrap_node.js:204:16)
    at bootstrap_node.js:625:3
```

Similar PR: https://github.com/geowarin/friendly-errors-webpack-plugin/pull/63