### PR TITLE
add Response.redirect API

### DIFF
--- a/packages/service-worker-mock/__tests__/Response.js
+++ b/packages/service-worker-mock/__tests__/Response.js
@@ -42,5 +42,19 @@ describe('Response', () => {
     expect(res.headers.get('X-Custom')).toEqual('custom-value');
   });
 
+  it('redirect creates a redirect response', () => {
+    const stringUrl = 'http://test.com/resource.html';
+    const res = Response.redirect(stringUrl, 301);
+
+    expect(res.headers.get('location')).toEqual(stringUrl);
+    expect(res.status).toEqual(301);
+  });
+
+  it('throws RangeError for a wrong status code', () => {
+    expect(() => {
+      Response.redirect('https://google.com/', 200);
+    }).toThrow(RangeError);
+  });
+
   it('should throw when trying to read body from opaque response');
 });

--- a/packages/service-worker-mock/__tests__/Response.js
+++ b/packages/service-worker-mock/__tests__/Response.js
@@ -56,5 +56,10 @@ describe('Response', () => {
     }).toThrow(RangeError);
   });
 
+  it('uses 302 as the default redirect code', () => {
+    const res = Response.redirect('http://test.com/resource.html');
+    expect(res.status).toEqual(302);
+  });
+
   it('should throw when trying to read body from opaque response');
 });

--- a/packages/service-worker-mock/models/Response.js
+++ b/packages/service-worker-mock/models/Response.js
@@ -46,6 +46,23 @@ class Response extends Body {
     });
   }
 
+  /**
+   * Creates a new response with a different URL.
+   * @param url The URL that the new response is to originate from.
+   * @param status [Optional] An optional status code for the response (e.g., 302.)
+   * @returns {Response}
+   */
+  static redirect(url, status) {
+    // see https://fetch.spec.whatwg.org/#dom-response-redirect
+    if (![301, 302, 303, 307, 308].includes(status)) {
+      throw new RangeError('Invalid status code');
+    }
+    return new Response(null, {
+      status: status,
+      headers: { Location: new URL(url).href }
+    });
+  }
+
   static error() {
     const errorResponse = new Response(null, {
       url: '',

--- a/packages/service-worker-mock/models/Response.js
+++ b/packages/service-worker-mock/models/Response.js
@@ -52,7 +52,7 @@ class Response extends Body {
    * @param status [Optional] An optional status code for the response (e.g., 302.)
    * @returns {Response}
    */
-  static redirect(url, status) {
+  static redirect(url, status = 302) {
     // see https://fetch.spec.whatwg.org/#dom-response-redirect
     if (![301, 302, 303, 307, 308].includes(status)) {
       throw new RangeError('Invalid status code');

--- a/testing/jest-setup.js
+++ b/testing/jest-setup.js
@@ -4,7 +4,7 @@ const Cache = require('./fixtures').Cache;
 const noop = () => {};
 
 // Browser globals
-global.URL = jest.fn(url => ({ search: url }));
+global.URL = jest.fn(url => ({ search: url, href: url }));
 global.Request = jest.fn(() => ({ url: '/' }));
 global.Response = Object;
 global.fetch = jest.fn(() => Promise.resolve({ status: 200 }));


### PR DESCRIPTION
Fixes https://github.com/pinterest/service-workers/issues/119 and adds a mock implementation for [Response.redirect](https://developer.mozilla.org/en-US/docs/Web/API/Response/redirect). 